### PR TITLE
Tap initially unapproved

### DIFF
--- a/Tabloid-Fullstack/Repositories/PostRepository.cs
+++ b/Tabloid-Fullstack/Repositories/PostRepository.cs
@@ -47,7 +47,7 @@ namespace Tabloid_Fullstack.Repositories
           .Include(p => p.PostReactions)
           .Include(p => p.PostTags)
           .Include(p => p.Comments)
-          .Where(p => p.Id == id && p.IsApproved && p.PublishDateTime < DateTime.Now)
+          .Where(p => p.Id == id && p.PublishDateTime < DateTime.Now)
           .FirstOrDefault();
     }
 

--- a/Tabloid-Fullstack/client/src/components/UserCard.js
+++ b/Tabloid-Fullstack/client/src/components/UserCard.js
@@ -143,7 +143,7 @@ const UserCard = ({ user, users }) => {
           <Button className="btn btn-outline-danger" onClick={(e) => {
             changeUserType();
             deactivateUser(user);
-            setPendingChange(true)
+            setPendingChange(false)
             Modal.isOpen = { pendingChange }
           }}>Yes, Change</Button>
         </ModalFooter>

--- a/Tabloid-Fullstack/client/src/pages/PostDetails.js
+++ b/Tabloid-Fullstack/client/src/pages/PostDetails.js
@@ -48,7 +48,7 @@ const PostDetails = () => {
       .then((data) => {
         if (data !== undefined) {
 
-          if (data.post.isApproved === 1) {
+          if (data.post.isApproved === true) {
             setPost(data.post);
             setReactionCounts(data.reactionCounts);
             getPostsTags(postId);
@@ -57,7 +57,7 @@ const PostDetails = () => {
             setReadTime(data.readTime);
           }
           if (data.post.isApproved !== 1) {
-            if (currentUser.id === data.post.userProfileId || currentUser.userTypeId === 1) {
+            if (currentUser.id === data.post.userProfileId || currentUser.userTypeId === true) {
               setPost(data.post);
               setReactionCounts(data.reactionCounts);
               getPostsTags(postId);

--- a/Tabloid-Fullstack/client/src/pages/PostDetails.js
+++ b/Tabloid-Fullstack/client/src/pages/PostDetails.js
@@ -65,7 +65,7 @@ const PostDetails = () => {
               getSubsByUser();
               setReadTime(data.readTime);
             }
-            if (currentUser.id !== data.post.userProfileId) {
+            if (currentUser.id !== data.post.userProfileId && currentUser.userTypeId === false) {
               toast.error("This isn't the post you're looking for");
             }
           }

--- a/Tabloid-Fullstack/client/src/pages/PostDetails.js
+++ b/Tabloid-Fullstack/client/src/pages/PostDetails.js
@@ -47,12 +47,28 @@ const PostDetails = () => {
         }))
       .then((data) => {
         if (data !== undefined) {
-          setPost(data.post);
-          setReactionCounts(data.reactionCounts);
-          getPostsTags(postId);
-          getTags();
-          getSubsByUser();
-          setReadTime(data.readTime);
+
+          if (data.post.isApproved === 1) {
+            setPost(data.post);
+            setReactionCounts(data.reactionCounts);
+            getPostsTags(postId);
+            getTags();
+            getSubsByUser();
+            setReadTime(data.readTime);
+          }
+          if (data.post.isApproved !== 1) {
+            if (currentUser.id === data.post.userProfileId || currentUser.userTypeId === 1) {
+              setPost(data.post);
+              setReactionCounts(data.reactionCounts);
+              getPostsTags(postId);
+              getTags();
+              getSubsByUser();
+              setReadTime(data.readTime);
+            }
+            if (currentUser.id !== data.post.userProfileId) {
+              toast.error("This isn't the post you're looking for");
+            }
+          }
         }
       });
   }, [postId]);

--- a/Tabloid-Fullstack/client/src/pages/PostForm.js
+++ b/Tabloid-Fullstack/client/src/pages/PostForm.js
@@ -75,8 +75,27 @@ const PostForm = () => {
             history.push("/login")
         }
         else {
+
+
+
+
+
+
+            console.log(user)
             newPost.categoryId = parseInt(newPost.categoryId)
-            newPost.isApproved = 1
+
+            if (user.userTypeId === 1) {
+                newPost.isApproved = 1
+            }
+
+            if (user.userTypeId === 2) {
+                newPost.isApproved = 0
+            }
+
+
+
+
+
             newPost.imageLocation = localStorage.getItem("image");
             if (isNaN(newPost.categoryId)) {
                 window.alert("You must select a category for this post!")
@@ -84,6 +103,15 @@ const PostForm = () => {
             else {
                 submitPost(newPost)
             }
+
+
+
+
+
+
+
+
+
         }
     }
 


### PR DESCRIPTION
This is a ticket and change of logic for how post details are rendered. Admin posts should initially be approved. Author posts should not be auto approved. You should also be able to go to post details for any posts, approved or not, if you are an admin. If you are an author, you should be able to go to post details for your own posts that have not been approved yet. Authors should not be able to see post details for other authors posts if the post has yet to be approved.

- [x] Create a post as an author and ensure it is initially automatically not approved
- [x] Create a post as an admin and ensure it is initially approved
- [x] Attempt to view an authors own unapproved posts while logged in as the posts author and ensure that is possible
- [ ] Attempt to view an authors unapproved posts while logged in as a different author than the posts author and ensure it is not possible
- [ ] Attempt to view an authors unapproved post while logged in as an admin and ensure that is possible

This was a lot to test so it is possible that I missed something. Please check this thoroughly!